### PR TITLE
format text in buffer and format before save

### DIFF
--- a/keymaps/clang-format.cson
+++ b/keymaps/clang-format.cson
@@ -1,3 +1,2 @@
 '.editor':
   'cmd-shift-k': 'clang-format:format'
-  'ctrl-s': 'clang-format:format-and-save'

--- a/keymaps/clang-format.cson
+++ b/keymaps/clang-format.cson
@@ -1,2 +1,3 @@
 '.editor':
   'cmd-shift-k': 'clang-format:format'
+  'ctrl-s': 'clang-format:format-and-save'

--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -24,7 +24,10 @@ class ClangFormat
       exe = atom.config.get('clang-format.executable')
       style = atom.config.get('clang-format.style')
       cursor = buffer.characterIndexForPosition(editor.getCursorBufferPosition())
-      child = exec exe + ' -cursor=' + cursor.toString() + ' -style ' + style, (err, stdout, stderr) =>
+      cmd = exe + ' -cursor=' + cursor.toString() + ' -style ' + style
+      if editor.getPath()
+        cmd += ' -assume-filename=' + editor.getPath()
+      child = exec cmd, (err, stdout, stderr) =>
         if err
           console.log(err)
           console.log(stdout)

--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -8,15 +8,13 @@ class ClangFormat
       if editor
         @format(editor)
 
-    atom.workspaceView.command 'clang-format:format-and-save', (e) =>
+    atom.workspaceView.command 'core:save', (e) =>
       editor = atom.workspace.getActiveEditor()
       if editor
         scope = editor.getCursorScopes()[0]
         if atom.config.get('clang-format.formatOnSave') and scope is 'source.c++'
-          @format editor, =>
+          @format editor, ->
             editor.save()
-        else
-          e.abortKeyBinding()
 
   format: (editor, onDone) ->
     if editor

--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -3,74 +3,38 @@ exec = require('child_process').exec
 module.exports =
 class ClangFormat
   constructor: (state) ->
-    atom.workspace.eachEditor (editor) =>
-      @handleBufferEvents(editor)
-
     atom.workspaceView.command 'clang-format:format', =>
       editor = atom.workspace.getActiveEditor()
       if editor
         @format(editor)
 
-  destroy: ->
-    atom.unsubscribe(atom.project)
+    atom.workspaceView.command 'clang-format:format-and-save', (e) =>
+      editor = atom.workspace.getActiveEditor()
+      if editor
+        scope = editor.getCursorScopes()[0]
+        if atom.config.get('clang-format.formatOnSave') and scope is 'source.c++'
+          @format editor, =>
+            editor.save()
+        else
+          e.abortKeyBinding()
 
-  handleBufferEvents: (editor) ->
-    buffer = editor.getBuffer()
-    atom.subscribe buffer, 'saved', =>
-      scope = editor.getCursorScopes()[0]
-      if atom.config.get('clang-format.formatOnSave') and scope is 'source.c++'
-        @format(editor)
-
-    atom.subscribe buffer, 'destroyed', ->
-      atom.unsubscribe(editor.getBuffer())
-
-  format: (editor) ->
-    if editor and editor.getPath()
+  format: (editor, onDone) ->
+    if editor
+      buffer = editor.getBuffer()
       exe = atom.config.get('clang-format.executable')
       style = atom.config.get('clang-format.style')
-      path = editor.getPath()
-      cursor = @getCurrentCursorPosition(editor)
-      exec exe + ' -cursor=' + cursor.toString() + ' -style ' + style + ' "' + path + '"', (err, stdout, stderr) =>
+      cursor = buffer.characterIndexForPosition(editor.getCursorBufferPosition())
+      child = exec exe + ' -cursor=' + cursor.toString() + ' -style ' + style, (err, stdout, stderr) =>
         if err
           console.log(err)
           console.log(stdout)
           console.log(stderr)
+          onDone() if onDone
         else
-          editor.setText(@getReturnedFormattedText(stdout))
-          returnedCursorPos = @getReturnedCursorPosition(stdout)
-          convertedCursorPos = @convertReturnedCursorPosition(editor, returnedCursorPos)
-          editor.setCursorBufferPosition(convertedCursorPos)
-
-  getEndJSONPosition: (text) ->
-    for i in [0..(text.length-1)]
-      if text[i] is '\n' or text[i] is '\r'
-        return i+1
-    return -1
-
-  getReturnedCursorPosition: (stdout) ->
-    parsed = JSON.parse stdout.slice(0, @getEndJSONPosition(stdout))
-    return parsed.Cursor
-
-  getReturnedFormattedText: (stdout) ->
-    return stdout.slice(@getEndJSONPosition(stdout))
-
-  getCurrentCursorPosition: (editor) ->
-    cursorPosition = editor.getCursorBufferPosition()
-    text = editor.getTextInBufferRange([[0, 0], cursorPosition])
-    return text.length
-
-  convertReturnedCursorPosition: (editor, position) ->
-    text = editor.getText()
-    x = y = 0
-
-    for i in [0..(text.length-1)]
-      if position is 0
-        return [y, x]
-      else if text[i] is '\n' or text[i] is '\r' or text[i] is '\f'
-        x = 0
-        y++
-      else
-        x++
-      position--
-
-    return [y, x]
+          [_, json, text] = stdout.match(/([^\r\n]+)\r?\n?([^]*)/)
+          editor.setText(text)
+          json = JSON.parse(json)
+          editor.setCursorBufferPosition(
+            buffer.positionForCharacterIndex(json.Cursor))
+          onDone() if onDone
+      child.stdin.end(editor.getText());


### PR DESCRIPTION
clang-format:format now formats the source in the buffer instead
of the one on disk.
When clang-format.formatOnSave is true, the source is formatted
before it is written to disk instead of after.