### PR TITLE
Handle new scope names for C++, Objective-C++

### DIFF
--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -18,7 +18,7 @@ class ClangFormat
     buffer = editor.getBuffer()
     atom.subscribe buffer, 'saved', =>
       scope = editor.getCursorScopes()[0]
-      if atom.config.get('clang-format.formatOnSave') and scope is 'source.c++'
+      if atom.config.get('clang-format.formatOnSave') and scope in ['source.c++', 'source.cpp']
         @format(editor)
 
     atom.subscribe buffer, 'destroyed', ->


### PR DESCRIPTION
In the next release of Atom (v0.166), the scope name for C++ and Objective-C++ will change from `source.c++` and `source.objc++` to `source.cpp` and `source.objcpp`. This is being done to work around some issues with CSS classes containing '+' characters. This PR adds handling for the new scope names, but will continue to handle the old ones, for compatibility with old versions of Atom.

Refs atom/language-c#54.
