### PR TITLE
Format all scopes supported by clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # clang-format package
 
-Format your C++ files with clang-format from inside atom. Requires clang-format to be installed and on your systems path.
+Format your C/C++/Obj-C files with clang-format from inside atom. Requires clang-format to be installed and on your systems path.
 
 More info on clang-format can be found here: http://clang.llvm.org/docs/ClangFormat.html http://clang.llvm.org/docs/ClangTools.html

--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -20,7 +20,7 @@ class ClangFormat
   handleBufferEvents: (editor) ->
     editor.onDidSave =>
       scope = editor.getRootScopeDescriptor().scopes[0]
-      if atom.config.get('clang-format.formatOnSave') and scope in ['source.c++', 'source.cpp']
+      if scope in atom.config.get('clang-format.formatOnSaveScopes')
         @format(editor)
 
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,9 +2,17 @@ ClangFormat = require './clang-format'
 
 module.exports =
   config:
-    formatOnSave:
-      type: 'boolean'
-      default: true
+    formatOnSaveScopes:
+      type: 'array'
+      item:
+        type: 'string'
+      default: [
+        'source.c'
+        'source.c++'
+        'source.cpp'
+        'source.objc'
+        'source.objcpp'
+      ]
     executable:
       type: 'string'
       default: 'clang-format'


### PR DESCRIPTION
Furthermore this allows the user to configure format on save per scope.