### PR TITLE
Improve overall experience during formatting.

### DIFF
--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -52,8 +52,11 @@ class ClangFormat
 
     # Call clang-format synchronously to ensure that save waits for us
     # Don't catch errors to make them visible to users via atom's UI
+    # We need to explicitly ignore stderr since there is no parent stderr on
+    # windows and node.js will try to write to it - whether it's there or not
     args = ("-#{k}=#{v}" for k, v of options).join ' '
-    stdout = execSync("#{exe} #{args}", input: editor.getText()).toString()
+    options = input: editor.getText(), stdio: ['pipe', 'pipe', 'ignore']
+    stdout = execSync("#{exe} #{args}", options).toString()
 
     # Update buffer with formatted text. setTextViaDiff minimizes re-rendering
     buffer.setTextViaDiff @getReturnedFormattedText(stdout)


### PR DESCRIPTION
This PR fixes some severe problems by introducing several changes:

1. Use `child_process.execSync` to call clang-format during `TextBuffer#onWillSave`.
   This ensures that the buffer will be formatted before being saved. Before this fix, the buffer always had unsaved changes after a format on save.

2. Use `TextBuffer#setTextViaDiff` to update the buffer contents.
   This reduces re-rendering and thus avoids flickering. Furthermore this preserves code folds. Actually this even preserves multiple cursors. However they are destroyed by this plugin's own cursor management logic.

3. Format buffer contents instead of file contents.
   Besides being a necessary precondition for 1, this allows to format unsaved files.