### PR TITLE
Avoid default fallback

### DIFF
--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -51,6 +51,7 @@ class ClangFormat
     options =
       style: atom.config.get('clang-format.style')
       cursor: @getCurrentCursorPosition(editor).toString()
+      'fallback-style': atom.config.get('clang-format.fallbackStyle')
 
     # Format only selection
     if @textSelected(editor)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,24 +5,36 @@ module.exports =
     formatCPlusPlusOnSave:
       type: 'boolean'
       default: true
+      title: 'Format C++ on save'
+      order: 1
     formatCOnSave:
       type: 'boolean'
       default: true
+      title: 'Format C on save'
+      order: 2
     formatObjectiveCOnSave:
       type: 'boolean'
       default: false
+      title: 'Format Objective-C on save'
+      order: 3
     formatJavascriptOnSave:
       type: 'boolean'
       default: false
+      title: 'Format JavaScript on save'
+      order: 4
     executable:
       type: 'string'
       default: ''
+      order: 5
     style:
       type: 'string'
       default: 'file'
+      order: 6
+      description: 'Default "file" uses the file ".clang-format" in one of the parent directories of the source file.'
     fallbackStyle:
       type: 'string'
       default: 'none'
+      description: 'Default "none" together with style "file" ensures that if no ".clang-format" file exists, no reformatting takes place.'
 
   activate: ->
     @clangFormat = new ClangFormat()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -20,6 +20,9 @@ module.exports =
     style:
       type: 'string'
       default: 'file'
+    fallbackStyle:
+      type: 'string'
+      default: 'none'
 
   activate: ->
     @clangFormat = new ClangFormat()


### PR DESCRIPTION
This adds the command line argument `-fallback-style=none` by default (value is configurable), which ensures that if no ".clang-format" file exists in the parent directories, no reformatting takes place.