### PR TITLE
Replace filenames

### DIFF
--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -70,7 +70,6 @@ class ClangFormat
     # We need to explicitly ignore stderr since there is no parent stderr on
     # windows and node.js will try to write to it - whether it's there or not
     args = ("-#{k}=\"#{v}\"" for k, v of options).join ' '
-    console.log("ARGS TO CLANG-FORMAT:", args)
     options = input: editor.getText(), stdio: ['pipe', 'pipe', 'ignore']
 
     if file_path = editor.getPath()

--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -57,8 +57,12 @@ class ClangFormat
     if @textSelected(editor)
       options.lines = @getTargetLineNums(editor)
 
-    # Pass file path to clang-format so it can look for .clang-format files
+    # Pass file path to clang-format so it can look for .clang-format files,
+    # modified if needed
     if file_path = editor.getPath()
+      replacements = JSON.parse(atom.config.get('clang-format.replaceExtensions'))
+      for [bad, good] in replacements
+        file_path = file_path.replace(new RegExp(bad + '$'), good)
       options['assume-filename'] = file_path
 
     # Call clang-format synchronously to ensure that save waits for us
@@ -66,6 +70,7 @@ class ClangFormat
     # We need to explicitly ignore stderr since there is no parent stderr on
     # windows and node.js will try to write to it - whether it's there or not
     args = ("-#{k}=\"#{v}\"" for k, v of options).join ' '
+    console.log("ARGS TO CLANG-FORMAT:", args)
     options = input: editor.getText(), stdio: ['pipe', 'pipe', 'ignore']
 
     if file_path = editor.getPath()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -40,7 +40,7 @@ module.exports =
       default: '[[]]'
       description: 'In order to call clang-format on files with non-standard
                     extensions, provide an array of 2-string arrays. Example:
-                    `[["cu","c"], ["md", "js"]]` to treat CUDA `.cu` files as
+                    `[["cu", "c"], ["md", "js"]]` to treat CUDA `.cu` files as
                     C files and Markdown files as JavaScript files.'
 
   activate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -35,6 +35,13 @@ module.exports =
       type: 'string'
       default: 'none'
       description: 'Default "none" together with style "file" ensures that if no ".clang-format" file exists, no reformatting takes place.'
+    replaceExtensions:
+      type: 'string'
+      default: '[[]]'
+      description: 'In order to call clang-format on files with non-standard
+                    extensions, provide an array of 2-string arrays. Example:
+                    `[["cu","c"], ["md", "js"]]` to treat CUDA `.cu` files as
+                    C files and Markdown files as JavaScript files.'
 
   activate: ->
     @clangFormat = new ClangFormat()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -37,7 +37,7 @@ module.exports =
       description: 'Default "none" together with style "file" ensures that if no ".clang-format" file exists, no reformatting takes place.'
     replaceExtensions:
       type: 'string'
-      default: '[[]]'
+      default: '[]'
       description: 'In order to call clang-format on files with non-standard
                     extensions, provide an array of 2-string arrays. Example:
                     `[["cu", "c"], ["md", "js"]]` to treat CUDA `.cu` files as


### PR DESCRIPTION
The user can now ask atom-clang-format to modify the filename (specifically, the extension) that it tells clang-format, to per the following from [Clang-Format documentation]: “When formatting standard input or a file that doesn’t have the extension corresponding to its language, -assume-filename= option can be used to override the file name clang-format uses to detect the language.”

The user can specify an array of 2-string tuples, e.g., `[["cu", "c"], ["md", "js"]]` as the default suggestion below shows:

<img width="701" alt="screen shot 2016-08-26 at 9 09 41 pm" src="https://cloud.githubusercontent.com/assets/37649/18024138/75a9d36a-6bd1-11e6-9742-660f45e73dd6.png">
