### PR TITLE
Fix error thrown when formatting empty C++ files

### DIFF
--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -113,6 +113,7 @@ class ClangFormat
     return -1
 
   getReturnedCursorPosition: (stdout) ->
+    return 0 unless stdout
     parsed = JSON.parse stdout.slice(0, @getEndJSONPosition(stdout))
     return parsed.Cursor
 


### PR DESCRIPTION
Fixes #67.

Does a check for a blank buffer before attempting to format it as C++ source.

Which is currently triggering this:

<img src="https://cloud.githubusercontent.com/assets/2346707/24742507/e1f4ac72-1aed-11e7-8fac-3765e216f28e.png" width="500" alt="Figure 1" />
