### PR TITLE
Allow use on TypeScript files

### DIFF
--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -102,6 +102,8 @@ class ClangFormat
       return true
     if atom.config.get('clang-format.formatJavascriptOnSave') and scope in ['source.js']
       return true
+    if atom.config.get('clang-format.formatTypescriptOnSave') and scope in ['source.ts']
+      return true
     if atom.config.get('clang-format.formatJavaOnSave') and scope in ['source.java']
       return true
     return false

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -22,19 +22,24 @@ module.exports =
       default: false
       title: 'Format JavaScript on save'
       order: 4
+    formatTypescriptOnSave:
+      type: 'boolean'
+      default: false
+      title: 'Format TypeScript on save'
+      order: 5
     formatJavaOnSave:
       type: 'boolean'
       default: false
       title: 'Format Java on save'
-      order: 5
+      order: 6
     executable:
       type: 'string'
       default: ''
-      order: 6
+      order: 7
     style:
       type: 'string'
       default: 'file'
-      order: 7
+      order: 8
       description: 'Default "file" uses the file ".clang-format" in one of the parent directories of the source file.'
     fallbackStyle:
       type: 'string'


### PR DESCRIPTION
Adds a menu option to run on TypeScript. Clang-Format already recognizes TypeScript files as JavaScript for formatting and formats them nicely.