### PR TITLE
fix: escape executable path in command line

### DIFF
--- a/lib/clang-format.coffee
+++ b/lib/clang-format.coffee
@@ -72,7 +72,7 @@ class ClangFormat
       options['cwd'] = path.dirname(file_path)
 
     try
-      stdout = execSync("#{exe} #{args}", options).toString()
+      stdout = execSync("\"#{exe}\" #{args}", options).toString()
         # Update buffer with formatted text. setTextViaDiff minimizes re-rendering
       buffer.setTextViaDiff @getReturnedFormattedText(stdout)
         # Restore cursor position


### PR DESCRIPTION
When the executable path contains spaces (eg: `C:\Program Files\LLVM\bin\clang-format.exe`), `child_process.execSync()` fails.