### PR TITLE
fix: use clang-format-binaries npm

### DIFF
--- a/lib/clang-format.js
+++ b/lib/clang-format.js
@@ -4,7 +4,7 @@ import { CompositeDisposable } from 'atom';
 import { execSync } from 'child_process';
 import os from 'os';
 import path from 'path';
-import clangFormatExecutables from 'clang-format';
+import clangFormatExecutables from 'clang-format-binaries';
 
 export default class ClangFormat {
   constructor() {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release": "semantic-release --ci --debug"
   },
   "dependencies": {
-    "clang-format": "github:angular/clang-format"
+    "clang-format-binaries": "^0.0.1"
   },
   "devDependencies": {
     "@semantic-release/apm": "^1.0.1",


### PR DESCRIPTION
use the npm package clang-format-binaries which is literally just the same as clang-format but because the name is different it dosen't clash and therfore we dont have to use git to refrence it in the package.json.